### PR TITLE
sd-network: include udev rules to apply predictable interface names

### DIFF
--- a/sd-network
+++ b/sd-network
@@ -16,6 +16,11 @@ build() {
     add_dir /etc/systemd/network
     (cd "$SD_NETWORK_CONFIG"; cp -ra -t "$BUILDROOT/etc/systemd/network" .)
 
+    # add necessary udev rules to apply predictable interface names
+    add_udev_rule /usr/lib/udev/rules.d/75-net-description.rules
+    add_udev_rule /usr/lib/udev/rules.d/80-net-setup-link.rules
+    add_file /usr/lib/systemd/network/99-default.link
+
     add_checked_modules /drivers/net
 
     # systemd-networkd.service requires user systemd-network
@@ -29,9 +34,9 @@ help() {
 This hook allows for initial network setup with systemd initramfs.
 
 It copies all necessary files, binaries and drivers to the initramfs. It
-enables systemd-networkd.service. Network configuration is copied from
-/etc/systemd/network or from \$SD_NETWORK_CONFIG if this variable specifies an
-existing directory. SD_NETWORK_CONFIG is supposed to be set in
-/etc/mkinitcpio.conf.
+enables systemd-networkd.service. It includes udev rules to apply predictable
+interface names. Network configuration is copied from /etc/systemd/network or
+from \$SD_NETWORK_CONFIG if this variable specifies an existing directory.
+SD_NETWORK_CONFIG is supposed to be set in /etc/mkinitcpio.conf.
 __EOF_HELP__
 }


### PR DESCRIPTION
Hey there,

I've been tinkering with the `sd-network` hook and mkinitcpio to figure out how to have udev apply predictable interface names early in the initramfs. My (and likely many others') network configuration files use udev's predictable interface names;

```ini
[Match]
Name=enp1s0f0
...
```

It is of course possible to match the interfaces based on something else such as their MAC addresses, the kernel ethX-names, or use separate configuration files for the initramfs, however in my case it lead to some issues down the line. I found the solution to it to be really simple; include the following files in the initramfs with `FILES` in `mkinitcpio.conf`:

```conf
FILES=(/usr/lib/udev/rules.d/75-net-description.rules /usr/lib/udev/rules.d/80-net-setup-link.rules /usr/lib/systemd/network/99-default.link)
```

These rules files seem to be enough for udev, in the initramfs, to pick up on every network interface (the `.link` file) and rename them according to the predictable interface name policy (the two `.rules` files). Afterwards networkd can use the "proper" names as it would in the actual system configuration.

In this PR I've modified the `sd-network` hook to include the three files. This is a breaking change, since previous possible methods of matching based on the kernel ethX-names will not work now that the interface names are changed. Would it be worthwhile adding a configuration option to disable adding the rules files and therefore disabling predictable interface names in the initramfs, therefore enabling the current behaviour of the kernel ethX-names?

Thanks!