### PR TITLE
sd-clevis: include clevis-decrypt-sss

### DIFF
--- a/sd-clevis
+++ b/sd-clevis
@@ -43,6 +43,7 @@ build() {
     add_binary clevis-luks-common-functions
     add_binary clevis-luks-unlock
     add_binary clevis-decrypt
+    add_binary clevis-decrypt-sss
 
     add_file /usr/lib/systemd/systemd-reply-password
 


### PR DESCRIPTION
Always include `clevis-decrypt-sss` binary to support the SSS-pin https://github.com/latchset/clevis?tab=readme-ov-file#pin-shamir-secret-sharing